### PR TITLE
fix(README): update spelling check badge link to correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Ícone de Diretriz da Stone Co.](https://img.shields.io/badge/STONE-diretriz-green?style=for-the-badge)
 ![Ícone de Boa Prática da Stone Co.](https://img.shields.io/badge/STONE-BOA%20PR%C3%81TICA-green?style=for-the-badge)
-[![Check spelling](https://github.com/stone-payments/stoneco-guidelines/actions/workflows/spell-checking.yaml/badge.svg)](https://github.com/stone-payments/stoneco-guidelines/actions/workflows/spell-checking.yaml)
+[![Check spelling](https://github.com/stone-payments/.github/actions/workflows/spell-checking.yaml/badge.svg)](https://github.com/stone-payments/.github/actions/workflows/spell-checking.yaml)
 
 _Esse documento está em processo de revisão em um Fórum de Boas Práticas e Comunidade Open Source da Stone Co. se você é colaborador e deseja participar procure no Slack por #temp-stone-open-source, para solicitar a entrada pode procurar @EndersonMenezes_
 


### PR DESCRIPTION
# Descrição

This pull request includes a small change to the `README.md` file. The change updates the link for the spell-checking badge to point to the correct repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated the URL for the spell-checking badge to `https://github.com/stone-payments/.github/actions/workflows/spell-checking.yaml`

---

# Checklist
Certifique-se de que os itens abaixo foram concluídos antes de enviar:

- [x] Testei as alterações localmente.
- [x] Atualizei qualquer documentação relevante.
- [x] Verifiquei que não há problemas de lint ou formatação.
- [x] Confirmei que o código segue as diretrizes de contribuição do projeto.
