### PR TITLE
feat(pr-template): move instructions to comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,16 @@
 # Descrição
-Por favor, forneça uma breve descrição das mudanças incluídas neste pull request.
+
+<!-- Por favor, forneça abaixo uma breve descrição das mudanças incluídas neste Pull Request -->
+
+
 
 ---
 
 # Checklist
-Certifique-se de que os itens abaixo foram concluídos antes de enviar:
+
+<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->
 
 - [ ] Testei as alterações localmente.
 - [ ] Atualizei qualquer documentação relevante.
-- [ ] Verifiquei que não há problemas de lint ou formatação.
+- [ ] Verifiquei que não há problemas de Lint ou formatação.
 - [ ] Confirmei que o código segue as diretrizes de contribuição do projeto.


### PR DESCRIPTION
# Descrição

<!-- Por favor, forneça abaixo uma breve descrição das mudanças incluídas neste Pull Request -->

Ajustei o template de PR para as instruções ficarem dentro de um comentário, dessa forma caso a pessoa não preencha o template ou esqueça de tirar, as instruções não aparecerão no PR.

Fiz outros pequenos ajustes, como `lint` -> `Lint` e `pull request` -> `Pull Request`, e ajustei a instrução do checklist para deixar mais claro como preencher.

---

# Checklist

<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->

- [x] Testei as alterações localmente.
- [x] Atualizei qualquer documentação relevante.
- [x] Verifiquei que não há problemas de Lint ou formatação.
- [x] Confirmei que o código segue as diretrizes de contribuição do projeto.
