### PR TITLE
chore: change runner from ubuntu-latest to ubuntu-slim

### DIFF
--- a/.github/workflows/spell-checking.yaml
+++ b/.github/workflows/spell-checking.yaml
@@ -13,7 +13,7 @@ on: # rebuild any PRs and main branch changes
 
 jobs:
   spellcheck: # run the action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Descrição

<!-- Por favor, forneça abaixo uma breve descrição das mudanças incluídas neste Pull Request -->

This pull request makes a minor update to the GitHub Actions workflow for spell checking by changing the runner environment to use a slimmer Ubuntu image. This helps reduce resource usage and potentially speeds up workflow execution.

- Workflow environment:
  * [`.github/workflows/spell-checking.yaml`](diffhunk://#diff-7a2fc012c0f7ab634cef90b98826b245bdc798682bc0e19913da4e034e94fbd6L16-R16): Changed the `runs-on` value from `ubuntu-latest` to `ubuntu-slim` for the `spellcheck` job.

---

# Checklist

<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->

- [X] Testei as alterações localmente.
- [X] Atualizei qualquer documentação relevante.
- [X] Verifiquei que não há problemas de Lint ou formatação.
- [X] Confirmei que o código segue as diretrizes de contribuição do projeto.
